### PR TITLE
Implement basic backend service with WebSocket streaming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ ultralytics
 torch
 scikit-learn
 tqdm
+
+fastapi
+uvicorn

--- a/src/backend_service.py
+++ b/src/backend_service.py
@@ -1,0 +1,150 @@
+"""Minimal backend service for scene presence monitoring."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import threading
+from typing import Dict, List, Tuple
+
+import cv2
+import numpy as np
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from scene_presence import ScenePresenceManager
+
+try:  # pragma: no cover - optional runtime dependency
+    from ultralytics import YOLO
+except Exception:  # pragma: no cover
+    YOLO = None
+
+
+# ---------------------------------------------------------------------------
+# Placeholder for secondary-system integration
+
+def get_current_roll_status() -> str:
+    """Return current steel roll status.
+
+    TODO: Replace with real implementation (MES / PLC / HTTP).
+    """
+
+    return "ready"  # possible values: "empty", "ready", "working", "done"
+
+
+# ---------------------------------------------------------------------------
+# Video capture worker (frame drop strategy)
+
+
+class VideoCaptureWorker(threading.Thread):
+    """Continuously grab frames from a video source."""
+
+    def __init__(self, source: int | str = 0) -> None:
+        super().__init__(daemon=True)
+        self.cap = cv2.VideoCapture(source)
+        if not self.cap.isOpened():
+            raise IOError(f"Cannot open {source}")
+        self.latest_frame: np.ndarray | None = None
+        self._running = True
+
+    def run(self) -> None:  # pragma: no cover - background loop
+        while self._running:
+            ret, frame = self.cap.read()
+            if ret:
+                self.latest_frame = frame
+            else:
+                break
+        self.cap.release()
+
+    def stop(self) -> None:
+        self._running = False
+
+
+# ---------------------------------------------------------------------------
+# Frame processor using ScenePresenceManager
+
+
+class FrameProcessor:
+    """Apply detection and update presence state."""
+
+    def __init__(self, model_name: str = "yolo11s", conf: float = 0.5) -> None:
+        self.manager = ScenePresenceManager()
+        self.conf = conf
+        self.detector = YOLO(model_name) if YOLO is not None else None
+
+    def process(self, frame: np.ndarray) -> np.ndarray:
+        """Run detection and draw status on ``frame``."""
+
+        detections: List[Tuple[int, Tuple[int, int, int, int]]] = []
+        if self.detector is not None:
+            results = self.detector.track(frame, conf=self.conf, persist=True)
+            boxes = results[0].boxes
+            ids = boxes.id if hasattr(boxes, "id") else None
+            if ids is not None:
+                for box, obj_id in zip(boxes.xyxy, ids):
+                    x1, y1, x2, y2 = map(int, box.tolist())
+                    detections.append((int(obj_id), (x1, y1, x2, y2)))
+        self.manager.update(detections)
+        self.manager.draw(frame)
+        return frame
+
+    def state(self) -> Dict[str, object]:
+        """Return current scene state."""
+
+        active_ids = [oid for oid, st in self.manager.workers.items() if st.status == "active"]
+        return {
+            "active_ids": active_ids,
+            "scene_active": self.manager.is_scene_active(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# FastAPI application
+
+
+capture_worker = VideoCaptureWorker()
+capture_worker.start()
+processor = FrameProcessor()
+app = FastAPI()
+
+
+@app.get("/inference/report")
+def inference_report() -> Dict[str, object]:
+    """Return scene presence report."""
+
+    frame = capture_worker.latest_frame
+    if frame is None:
+        return {"detail": "no frame"}
+    processor.process(frame.copy())
+    data = processor.state()
+    data["roll_status"] = get_current_roll_status()
+    return data
+
+
+@app.websocket("/status")
+async def websocket_endpoint(ws: WebSocket) -> None:
+    """Stream processed frames and status to clients."""
+
+    await ws.accept()
+    try:
+        while True:
+            frame = capture_worker.latest_frame
+            if frame is None:
+                await asyncio.sleep(0.1)
+                continue
+            processed = processor.process(frame.copy())
+            ret, buf = cv2.imencode(".jpg", processed)
+            if not ret:
+                await asyncio.sleep(0.1)
+                continue
+            b64 = base64.b64encode(buf).decode("ascii")
+            payload = processor.state()
+            payload["roll_status"] = get_current_roll_status()
+            payload["frame"] = b64
+            await ws.send_json(payload)
+            await asyncio.sleep(0.1)
+    except WebSocketDisconnect:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# The module exposes ``app`` for ASGI servers like uvicorn.

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -97,7 +97,7 @@ class DataPipeline:
                         box_array = np.stack(box_seq[:window_size], axis=0)
                         file_path = os.path.join(
                             output_dir,
-                            f"{os.path.basename(video_path)}_{obj_id}.{label}_{start_frame}.npz",
+                            f"{os.path.basename(str(video_path))}_{obj_id}.{label}_{start_frame}.npz",
                         )
                         np.savez_compressed(file_path, data=array, boxes=box_array, label=label)
                         saved_files.append(file_path)


### PR DESCRIPTION
## Summary
- introduce `backend_service` FastAPI app with frame capture, presence processing, and WebSocket streaming
- stub secondary-system `get_current_roll_status` and integrate with scene presence manager
- add FastAPI and Uvicorn to dependencies

## Testing
- `python -m py_compile src/backend_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689154ba7f448326829e265d18745aed