### PR TITLE
Implement basic backend service with WebSocket streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,28 @@ python src/scene_presence.py --video 0 --model yolo11s
 
 运行窗口中按 `r` 可重新绘制监控区域（左键添加顶点，空格或回车结束，Esc 取消），按 `q` 退出。若任一 ID 处于 `active` 状态，界面左上角会显示 `ACTIVE`，否则为 `INACTIVE`。如需在后台运行或关闭可视化，可加 `--no-display` 参数。
 
+
+## 后端服务接口
+
+仓库提供了一个基于 FastAPI 的后端服务 `src/backend_service.py`，用于实时返回场景在岗状态并推送处理后的画面。
+
+### 启动方式
+
+```bash
+uvicorn src.backend_service:app
+```
+
+### 可用接口
+
+- `GET /inference/report`：返回当前在岗人员 ID、场景总体状态以及钢卷状态。
+- `WS /status`：通过 WebSocket 持续发送 JSON 数据，其中 `frame` 字段为 Base64 编码的 JPEG 图像。
+
+前端可直接订阅 `/status` 接口以显示处理后的帧并实时获取在岗信息。
+
+## 运行测试
+
+项目使用 `pytest` 进行测试。运行所有测试：
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ ultralytics
 torch
 scikit-learn
 tqdm
+
+fastapi
+uvicorn
+httpx

--- a/src/backend_service.py
+++ b/src/backend_service.py
@@ -1,0 +1,150 @@
+"""Minimal backend service for scene presence monitoring."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import threading
+from typing import Dict, List, Tuple
+
+import cv2
+import numpy as np
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from scene_presence import ScenePresenceManager
+
+try:  # pragma: no cover - optional runtime dependency
+    from ultralytics import YOLO
+except Exception:  # pragma: no cover
+    YOLO = None
+
+
+# ---------------------------------------------------------------------------
+# Placeholder for secondary-system integration
+
+def get_current_roll_status() -> str:
+    """Return current steel roll status.
+
+    TODO: Replace with real implementation (MES / PLC / HTTP).
+    """
+
+    return "ready"  # possible values: "empty", "ready", "working", "done"
+
+
+# ---------------------------------------------------------------------------
+# Video capture worker (frame drop strategy)
+
+
+class VideoCaptureWorker(threading.Thread):
+    """Continuously grab frames from a video source."""
+
+    def __init__(self, source: int | str = 0) -> None:
+        super().__init__(daemon=True)
+        self.cap = cv2.VideoCapture(source)
+        if not self.cap.isOpened():
+            raise IOError(f"Cannot open {source}")
+        self.latest_frame: np.ndarray | None = None
+        self._running = True
+
+    def run(self) -> None:  # pragma: no cover - background loop
+        while self._running:
+            ret, frame = self.cap.read()
+            if ret:
+                self.latest_frame = frame
+            else:
+                break
+        self.cap.release()
+
+    def stop(self) -> None:
+        self._running = False
+
+
+# ---------------------------------------------------------------------------
+# Frame processor using ScenePresenceManager
+
+
+class FrameProcessor:
+    """Apply detection and update presence state."""
+
+    def __init__(self, model_name: str = "yolo11s", conf: float = 0.5) -> None:
+        self.manager = ScenePresenceManager()
+        self.conf = conf
+        self.detector = YOLO(model_name) if YOLO is not None else None
+
+    def process(self, frame: np.ndarray) -> np.ndarray:
+        """Run detection and draw status on ``frame``."""
+
+        detections: List[Tuple[int, Tuple[int, int, int, int]]] = []
+        if self.detector is not None:
+            results = self.detector.track(frame, conf=self.conf, persist=True)
+            boxes = results[0].boxes
+            ids = boxes.id if hasattr(boxes, "id") else None
+            if ids is not None:
+                for box, obj_id in zip(boxes.xyxy, ids):
+                    x1, y1, x2, y2 = map(int, box.tolist())
+                    detections.append((int(obj_id), (x1, y1, x2, y2)))
+        self.manager.update(detections)
+        self.manager.draw(frame)
+        return frame
+
+    def state(self) -> Dict[str, object]:
+        """Return current scene state."""
+
+        active_ids = [oid for oid, st in self.manager.workers.items() if st.status == "active"]
+        return {
+            "active_ids": active_ids,
+            "scene_active": self.manager.is_scene_active(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# FastAPI application
+
+
+capture_worker = VideoCaptureWorker()
+capture_worker.start()
+processor = FrameProcessor()
+app = FastAPI()
+
+
+@app.get("/inference/report")
+def inference_report() -> Dict[str, object]:
+    """Return scene presence report."""
+
+    frame = capture_worker.latest_frame
+    if frame is None:
+        return {"detail": "no frame"}
+    processor.process(frame.copy())
+    data = processor.state()
+    data["roll_status"] = get_current_roll_status()
+    return data
+
+
+@app.websocket("/status")
+async def websocket_endpoint(ws: WebSocket) -> None:
+    """Stream processed frames and status to clients."""
+
+    await ws.accept()
+    try:
+        while True:
+            frame = capture_worker.latest_frame
+            if frame is None:
+                await asyncio.sleep(0.1)
+                continue
+            processed = processor.process(frame.copy())
+            ret, buf = cv2.imencode(".jpg", processed)
+            if not ret:
+                await asyncio.sleep(0.1)
+                continue
+            b64 = base64.b64encode(buf).decode("ascii")
+            payload = processor.state()
+            payload["roll_status"] = get_current_roll_status()
+            payload["frame"] = b64
+            await ws.send_json(payload)
+            await asyncio.sleep(0.1)
+    except WebSocketDisconnect:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# The module exposes ``app`` for ASGI servers like uvicorn.

--- a/tests/test_backend_service.py
+++ b/tests/test_backend_service.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+from fastapi.testclient import TestClient
+
+
+def test_inference_report(monkeypatch):
+    """Smoke test the /inference/report endpoint."""
+
+    class DummyCap:
+        def __init__(self, *args, **kwargs):
+            self.frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+        def isOpened(self):
+            return True
+
+        def read(self):
+            return True, self.frame
+
+        def release(self):
+            pass
+
+    dummy_cv2 = types.SimpleNamespace()
+    dummy_cv2.VideoCapture = lambda *a, **k: DummyCap()
+    dummy_cv2.imencode = lambda *a, **k: (True, b"")
+    monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
+
+    sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+    backend_service = importlib.import_module("backend_service")
+
+    # stop background thread and stub processor/state for deterministic test
+    backend_service.capture_worker.stop()
+    backend_service.capture_worker.latest_frame = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    class DummyProcessor:
+        @staticmethod
+        def process(frame):
+            return frame
+
+        @staticmethod
+        def state():
+            return {"active_ids": [], "scene_active": False}
+
+    backend_service.processor = DummyProcessor()
+
+    client = TestClient(backend_service.app)
+    resp = client.get("/inference/report")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["roll_status"] == "ready"
+    assert "scene_active" in data


### PR DESCRIPTION
## Summary
- introduce `backend_service` FastAPI app with frame capture, presence processing, and WebSocket streaming
- stub secondary-system `get_current_roll_status` and integrate with scene presence manager
- add FastAPI and Uvicorn to dependencies
- document backend service and add smoke test for `/inference/report`

## Testing
- `python -m py_compile src/backend_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689154ba7f448326829e265d18745aed