### PR TITLE
Add detection filtering to scene presence demo

### DIFF
--- a/src/backend_service.py
+++ b/src/backend_service.py
@@ -11,7 +11,7 @@ import cv2
 import numpy as np
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
-from src.scene_presence import ScenePresenceManager
+from scene_presence import ScenePresenceManager
 
 try:  # pragma: no cover - optional runtime dependency
     from ultralytics import YOLO


### PR DESCRIPTION
## Summary
- filter tracked detections by class and bounding-box size using configurable options
- expose CLI overrides for allowed classes and minimum box area
- fix backend service import path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a016a8c483268069c0cd49fae92f