### PR TITLE
feat: minimal frontend and snapshot endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
     const frameImg = document.getElementById("frame");
     const infoDiv = document.getElementById("info");
 
-    const socket = new WebSocket("ws://localhost:8000/status");
+    const wsProto = location.protocol === "https:" ? "wss" : "ws";
+    const socket = new WebSocket(`${wsProto}://${location.host}/status`);
 
     socket.onopen = () => {
       statusDiv.textContent = "✅ Connected to backend";


### PR DESCRIPTION
## Summary
- serve index.html from FastAPI backend
- add snapshot API to fetch processed frame and recognition state
- make frontend websocket connect to server host dynamically

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad129d069c8326b5d0cec054cc8a9e