### PR TITLE
feat: allow optional video source

### DIFF
--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -22,7 +22,7 @@ def load_config(path: Path | None = None, default: Dict[str, Any] | None = None)
     """
     cfg_path = path or CONFIG_FILE
     config: Dict[str, Any] = {
-        "source": 0,
+        "source": None,
         "region": None,
     }
     if default:

--- a/tests/test_backend_service.py
+++ b/tests/test_backend_service.py
@@ -31,9 +31,10 @@ def test_inference_report(monkeypatch):
     sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
     backend = importlib.import_module("backend.service")
 
-    # stop background thread and stub processor/state for deterministic test
-    backend.capture_worker.stop()
-    backend.capture_worker.latest_frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    backend.set_source(0)
+    if backend.capture_worker is not None:
+        backend.capture_worker.stop()
+        backend.capture_worker.latest_frame = np.zeros((4, 4, 3), dtype=np.uint8)
 
     class DummyProcessor:
         @staticmethod


### PR DESCRIPTION
## Summary
- allow backend to start without a camera by default
- add runtime source switching helper and handle missing frames
- update tests for new capture setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad230e43208326bbf3becdc2ee70c9