### PR TITLE
Add ROI calibration tool for easier region setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ PY
 
 脚本 `src/scene_presence.py` 提供了基于状态机的多人在岗检测逻辑，并支持交互式调整**任意多边形**监控区域。程序会根据各 ID 在区域内的连续帧数判断其状态（pending/active/paused/finished），同时在窗口中绘制状态色框和场景总体状态。监控区域会以半透明色块高亮显示，并将调整后的多边形保存到 `scene_presence_config.json`，下次运行时自动加载。默认监控区域为整张画面的四边形。配置文件还会记录检测模型、置信度及状态机阈值（`enter_frames`、`leave_frames`、`finish_frames`），命令行参数会覆盖这些值并写回配置文件。
 
+如仅需快速标定区域，可运行 `src/roi_calibrator.py` 读取视频流首帧并交互式绘制多边形，结果会写入同一个 `scene_presence_config.json`，后续 `scene_presence.py` 会直接使用该区域：
+
+```bash
+python src/roi_calibrator.py --video 0
+```
+
 
 运行示例：
 

--- a/src/roi_calibrator.py
+++ b/src/roi_calibrator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Simple ROI calibration tool that captures a frame and saves polygon region."""
+
+import argparse
+from pathlib import Path
+
+import cv2
+
+from scene_presence import CONFIG_FILE, load_config, save_config, select_polygon
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interactive ROI calibration")
+    parser.add_argument(
+        "--video", default=0, help="Video source index or file path"
+    )
+    parser.add_argument(
+        "--config", default=str(CONFIG_FILE), help="Output configuration file"
+    )
+    args = parser.parse_args()
+
+    src: str | int
+    src = int(args.video) if str(args.video).isdigit() else args.video
+    cap = cv2.VideoCapture(src)
+    if not cap.isOpened():
+        raise SystemExit(f"Cannot open {args.video}")
+
+    ret, frame = cap.read()
+    cap.release()
+    if not ret:
+        raise SystemExit("Failed to read from video source")
+
+    poly = select_polygon("roi_calibration", frame)
+    cv2.destroyAllWindows()
+    if not poly:
+        print("No region selected; nothing saved")
+        return
+
+    cfg_path = Path(args.config)
+    config = load_config(cfg_path, {})
+    config["region"] = poly
+    save_config(cfg_path, config)
+    print(f"Saved region with {len(poly)} points to {cfg_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI usage
+    main()


### PR DESCRIPTION
## Summary
- add `roi_calibrator.py` to capture a frame and save polygon region
- document calibration workflow in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad4dcbaa54832694d33fce651c2041