### PR TITLE
feat: support timing thresholds in scene presence config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ PY
 ## 场景级人员在岗检测
 
 
-脚本 `src/scene_presence.py` 提供了基于状态机的多人在岗检测逻辑，并支持交互式调整**任意多边形**监控区域。程序会根据各 ID 在区域内的**驻留时间**判断其状态（pending/active/paused/finished），同时在窗口中绘制状态色框和场景总体状态。监控区域会以半透明色块高亮显示，并将调整后的多边形保存到 `scene_presence_config.json`，下次运行时自动加载。默认监控区域为整张画面的四边形。配置文件记录检测模型、置信度及时间阈值（`enter_ms`、`leave_ms`、`finish_ms`），命令行参数可覆盖这些值并写回配置文件。支持同时以毫秒或秒传入阈值（例如 `--enter-ms 500` 或 `--enter-s 0.5`），配置文件的字段说明见 `scene_presence_config.schema.json`。
+脚本 `src/scene_presence.py` 提供了基于状态机的多人在岗检测逻辑，并支持交互式调整**任意多边形**监控区域。程序会根据各 ID 在区域内的**驻留时间**判断其状态（pending/active/paused/finished），同时在窗口中绘制状态色框和场景总体状态。监控区域会以半透明色块高亮显示，并将调整后的多边形保存到 `scene_presence_config.json`，下次运行时自动加载。默认监控区域为整张画面的四边形。配置文件记录检测模型、置信度及时间阈值，这些阈值位于 `timing` 字段下（`enter_s`、`leave_s`、`finish_s`），命令行参数可覆盖这些值并写回配置文件。支持同时以毫秒或秒传入阈值（例如 `--enter-ms 500` 或 `--enter-s 0.5`），配置文件的字段说明见 `scene_presence_config.schema.json`。
 
 如仅需快速标定区域，可运行 `src/roi_calibrator.py` 读取视频流首帧并交互式绘制多边形，结果会写入同一个 `scene_presence_config.json`，后续 `scene_presence.py` 会直接使用该区域：
 

--- a/scene_presence_config.schema.json
+++ b/scene_presence_config.schema.json
@@ -14,9 +14,16 @@
     },
     "model_name": {"type": "string"},
     "conf": {"type": "number"},
-    "enter_ms": {"type": "number"},
-    "leave_ms": {"type": "number"},
-    "finish_ms": {"type": ["number", "null"]},
+    "timing": {
+      "type": "object",
+      "properties": {
+        "enter_s": {"type": "number"},
+        "leave_s": {"type": "number"},
+        "finish_s": {"type": ["number", "null"]}
+      },
+      "required": ["enter_s", "leave_s"],
+      "additionalProperties": false
+    },
     "classes": {
       "type": "array",
       "items": {"type": "string"}
@@ -27,8 +34,7 @@
     "region",
     "model_name",
     "conf",
-    "enter_ms",
-    "leave_ms",
+    "timing",
     "classes",
     "min_area"
   ],

--- a/src/scene_presence.py
+++ b/src/scene_presence.py
@@ -286,9 +286,7 @@ def run_demo(
         "region": [(0, 0), (w - 1, 0), (w - 1, h - 1), (0, h - 1)],
         "model_name": "yolo11s",
         "conf": 0.5,
-        "enter_ms": 500.0,
-        "leave_ms": 1000.0,
-        "finish_ms": None,
+        "timing": {"enter_s": 0.5, "leave_s": 1.0, "finish_s": None},
         # Filter detections: only keep specified classes and discard small boxes.
         # ``classes`` uses YOLO class names, e.g. ["person"].
         "classes": ["person"],
@@ -302,18 +300,19 @@ def run_demo(
         config["model_name"] = model_name
     if conf is not None:
         config["conf"] = conf
+    timing = config.setdefault("timing", {})
     if enter_ms is not None:
-        config["enter_ms"] = enter_ms
+        timing["enter_s"] = enter_ms / 1000.0
     if leave_ms is not None:
-        config["leave_ms"] = leave_ms
+        timing["leave_s"] = leave_ms / 1000.0
     if finish_ms is not None:
-        config["finish_ms"] = finish_ms
+        timing["finish_s"] = finish_ms / 1000.0
     if enter_s is not None:
-        config["enter_ms"] = enter_s * 1000.0
+        timing["enter_s"] = enter_s
     if leave_s is not None:
-        config["leave_ms"] = leave_s * 1000.0
+        timing["leave_s"] = leave_s
     if finish_s is not None:
-        config["finish_ms"] = finish_s * 1000.0
+        timing["finish_s"] = finish_s
     if classes is not None:
         config["classes"] = classes
     if min_area is not None:
@@ -323,11 +322,12 @@ def run_demo(
 
     detector = YOLO(config["model_name"])
     conf = float(config["conf"])
+    timing = config.get("timing", {})
     manager = ScenePresenceManager(
         region=config["region"],
-        enter_ms=float(config["enter_ms"]),
-        leave_ms=float(config["leave_ms"]),
-        finish_ms=config.get("finish_ms"),
+        enter_s=float(timing.get("enter_s", 0.5)),
+        leave_s=float(timing.get("leave_s", 1.0)),
+        finish_s=timing.get("finish_s"),
     )
     if not is_rtsp:
         cap.set(cv2.CAP_PROP_POS_FRAMES, 0)

--- a/tests/test_scene_presence_config.py
+++ b/tests/test_scene_presence_config.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from scene_presence import load_config, save_config, ScenePresenceManager
+
+def test_timing_section_roundtrip(tmp_path):
+    default = {
+        "region": None,
+        "model_name": "yolo11s",
+        "conf": 0.5,
+        "timing": {"enter_s": 0.5, "leave_s": 1.0, "finish_s": None},
+        "classes": ["person"],
+        "min_area": 10,
+    }
+    cfg = tmp_path / "cfg.json"
+    cfg_data = load_config(cfg, default)
+    assert cfg_data["timing"]["enter_s"] == 0.5
+
+    cfg_data["timing"]["enter_s"] = 1.5
+    save_config(cfg, cfg_data)
+    loaded = load_config(cfg, default)
+    assert loaded["timing"]["enter_s"] == 1.5
+
+    mgr = ScenePresenceManager(
+        enter_s=loaded["timing"]["enter_s"],
+        leave_s=loaded["timing"]["leave_s"],
+    )
+    assert mgr.enter_ms == 1500.0
+    assert mgr.leave_ms == 1000.0


### PR DESCRIPTION
## Summary
- group ScenePresenceManager thresholds under `timing` and allow seconds-based config
- document new timing section and update JSON schema
- add test covering timing config roundtrip

## Testing
- `pip install -r requirements.txt`
- `pip install opencv-python-headless`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad675dc7748326af1d899e312ad7ba